### PR TITLE
Updates for new Node and Puppeteer versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .git
 .gitignore
-.travis.yml
 renovate.json
 LICENSE
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,59 @@
-FROM node:13-slim
+FROM node:14-slim
 
-LABEL name="puppeter"
+LABEL name="puppeteer"
 LABEL maintainer="UltimaPhoenix"
-LABEL version="1.0.0"
+LABEL version="2.0.0"
 LABEL description="Base docker puppeteer image"
 
+# Manually install missing shared libs for Chromium.
+RUN apt-get update && apt-get install -yq \
+    gconf-service \
+    libasound2 \
+    libatk1.0-0 \
+    libc6 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgcc1 \
+    libgconf-2-4 \
+    libgdk-pixbuf2.0-0 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    libxtst6 \
+    ca-certificates \
+    fonts-liberation \
+    libappindicator1 \
+    libnss3 \
+    lsb-release \
+    xdg-utils \
+    wget
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libx11-6 libx11-dev libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 \
-        libxext6 libxi6 libxtst6 libglib2.0-0 libnss3 libcups2 \
-        libxss1 libxrandr2 libasound2 libpangocairo-1.0 \
-        libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get purge -y --auto-remove
+# If running Docker >= 1.13.0 use docker run's --init arg to reap zombie processes, otherwise
+# uncomment the following lines to have `dumb-init` as PID 1
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_x86_64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+ENTRYPOINT ["dumb-init", "--"]
+
+# Add user to run as unprivileged user.
+RUN groupadd -r puppeteer && \
+    useradd --create-home --no-log-init -r -g puppeteer -G audio,video puppeteer
 
 CMD /bin/bash
-
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# docker-puppeteer [![Docker Pulls](https://img.shields.io/docker/pulls/ultimaphoenix/puppeteer.svg)](https://hub.docker.com/r/ultimaphoenix/puppeteer/) [![Docker Stars](https://img.shields.io/docker/stars/ultimaphoenix/puppeteer.svg)](https://hub.docker.com/r/ultimaphoenix/puppeteer/) [![Docker Automated build](https://img.shields.io/docker/automated/ultimaphoenix/puppeteer.svg)](https://hub.docker.com/r/ultimaphoenix/puppeteer/) [![Docker Build Status](https://img.shields.io/docker/build/ultimaphoenix/puppeteer.svg)](https://hub.docker.com/r/ultimaphoenix/puppeteer/)
-Base docker puppeteer image
+# puppeteer
+
+[![dockeri.co](https://dockeri.co/image/ultimaphoenix/puppeteer)](https://hub.docker.com/r/ultimaphoenix/puppeteer)
+
+[![Docker Automated build](https://img.shields.io/docker/automated/ultimaphoenix/puppeteer.svg)](https://hub.docker.com/r/ultimaphoenix/puppeteer/)
+
+Base docker image for [Puppeteer](https://developers.google.com/web/tools/puppeteer).
+
+## Usage
+
+You should launch the browser with the following arguments:
+
+```js
+const browser = await puppeteer.launch({
+  args: ['--no-sandbox', '--disable-setuid-sandbox']
+});
+```
+
+Assuming that your app has a structure like this:
+```
+my-app/
+├── .dockerignore
+├── Dockerfile
+├── package.json
+├── puppeteer.js
+└── README.md
+```
+Include the following lines in your `Dockerfile`:
+```
+FROM ultimaphoenix/puppeteer
+
+COPY package.json /home/puppeteer
+COPY puppeteer.js /home/puppeteer
+RUN chown -R puppeteer:puppeteer /home/puppeteer/package.json \
+    && chown -R puppeteer:puppeteer /home/puppeteer/puppeteer.js
+
+# Run everything after as non-privileged user.
+USER puppeteer
+WORKDIR /home/puppeteer
+
+RUN npm install
+
+CMD ["node", "puppeteer.js"]
+```
+
+## What to know to run Puppeteer on Docker
+
+>By default, Docker runs a container with a `/dev/shm` shared memory space 64MB.
+This is [typically too small](https://github.com/c0b/chrome-in-docker/issues/1) for Chrome
+and will cause Chrome to crash when rendering large pages. To fix, run the container with
+`docker run --shm-size=1gb` to increase the size of `/dev/shm`. Since Chrome 65, this is no
+longer necessary. Instead, launch the browser with the `--disable-dev-shm-usage` flag:
+>
+>```js
+>const browser = await puppeteer.launch({
+>  args: ['--disable-dev-shm-usage']
+>});
+>```
+>
+>This will write shared memory files into `/tmp` instead of `/dev/shm`. See [crbug.com/736452](https://bugs.chromium.org/p/chromium/issues/detail?id=736452) for more details.
+>
+> &mdash; The [official Puppeteer documentation](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#tips)
+
+If you encounter other errors not mentioned here, please refer to the [official Puppeteer documentation](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md).


### PR DESCRIPTION
- Update Node version to 14, since it's the latest Maintenance LTS, as [required by Puppeteer](https://github.com/puppeteer/puppeteer#usage)
- Update the required packages to be installed, as in [the official sample](https://github.com/ebidel/try-puppeteer/blob/master/backend/Dockerfile)
- Add a workaround to reap zombie processes, as in [the official documentation](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker)
```
# If running Docker >= 1.13.0 use docker run's --init arg to reap zombie processes, otherwise
# uncomment the following lines to have `dumb-init` as PID 1
ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_x86_64 /usr/local/bin/dumb-init
RUN chmod +x /usr/local/bin/dumb-init
ENTRYPOINT ["dumb-init", "--"]
```
- Add `puppeteer` unprivileged user
- Update documentation with the required information to get up and running.
- Cleanup